### PR TITLE
fix: add missing 'svix' dependency required for Clerk webhook

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-resizable-panels": "^3.0.3",
     "recharts": "2.15.4",
     "sonner": "^2.0.6",
+    "svix": "^1.69.0",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
     "zod": "^4.0.5"


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies to include the latest version of "svix".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->