### PR TITLE
fix: ignore prisma generated files in eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,3 +1,4 @@
+
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
@@ -11,6 +12,11 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+
+  // Ignore all files in src/generated/
+  {
+    ignores: ["src/generated/**/*.{js,ts}"],
+  },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to exclude files in the `src/generated/` directory from linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->