### PR TITLE
feat(post-feed): Implement infinite scroll and pagination

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "react-day-picker": "^9.8.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.60.0",
+        "react-intersection-observer": "^9.16.0",
         "react-resizable-panels": "^3.0.3",
         "recharts": "2.15.4",
         "sonner": "^2.0.6",
@@ -1114,6 +1115,8 @@
     "react-dom": ["react-dom@19.1.0", "", { "dependencies": { "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.0" } }, "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g=="],
 
     "react-hook-form": ["react-hook-form@7.60.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A=="],
+
+    "react-intersection-observer": ["react-intersection-observer@9.16.0", "", { "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["react-dom"] }, "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-day-picker": "^9.8.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.60.0",
+    "react-intersection-observer": "^9.16.0",
     "react-resizable-panels": "^3.0.3",
     "recharts": "2.15.4",
     "sonner": "^2.0.6",

--- a/src/app/api/posts/for-you/route.ts
+++ b/src/app/api/posts/for-you/route.ts
@@ -1,19 +1,23 @@
 import { prisma } from "@/lib/prisma";
+import type { PostsPage } from "@/lib/types";
 import { auth } from "@clerk/nextjs/server";
-import { NextResponse } from "next/server";
+import { NextResponse, NextRequest } from "next/server";
 
 /**
  * GET /api/posts/for-you
  *
- * This endpoint returns a feed of posts for the currently authenticated user.
+ * This endpoint returns a paginated feed of posts for the currently authenticated user.
  * It relies on Clerk’s `auth()` function to verify the user’s session.
  *
+ * Query Parameters:
+ *   cursor (optional): A post ID to use as a cursor for pagination. Posts created before this ID will be returned.
+ *
  * Response codes:
- *   200 – OK, returns the array of post objects
+ *   200 – OK, returns an object containing an array of post objects and a nextCursor for pagination.
  *   401 – Unauthorized (no valid Clerk session)
  *   500 – Internal Server Error (unexpected exception)
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   // Retrieve Clerk-authenticated user ID from the session.
   // If there’s no valid session, `userId` will be undefined.
   const { userId: authenticatedUserId } = await auth();
@@ -25,9 +29,16 @@ export async function GET() {
       { status: 401 }
     );
   }
+
+  // Extract the cursor from the request query parameters.
+  const cursor = request.nextUrl.searchParams.get("cursor") || undefined;
+  const pageSize = 10; // Number of posts to fetch per request
+
   try {
     //
-    // Query Prisma for all posts, including user details.
+    // Query Prisma for a paginated list of posts, including user details.
+    // The `take` value fetches one more than `pageSize` to determine if there's a next page.
+    // The `cursor` is used for pagination to fetch posts created before a specific post ID.
     //
     const posts = await prisma.post.findMany({
       include: {
@@ -43,10 +54,23 @@ export async function GET() {
       orderBy: {
         createdAt: "desc",
       },
+      take: pageSize + 1,
+      cursor: cursor ? { id: cursor } : undefined,
     });
 
+    // Determine the next cursor for pagination. If more posts were fetched than the page size,
+    // the last post's ID becomes the next cursor; otherwise, there are no more pages.
+    const nextCursor =
+      posts.length > pageSize ? posts[posts.length - 1].id : null;
+
+    // Prepare the response data, slicing the posts to the requested page size.
+    const data: PostsPage = {
+      posts: posts.slice(0, pageSize),
+      nextCursor,
+    };
+
     // If found, return the entire array of Post objects (JSON).
-    return NextResponse.json(posts);
+    return NextResponse.json(data);
   } catch (error) {
     // If anything goes wrong (e.g., database connectivity), log and return 500.
     console.log("Error fetching posts: ", error);

--- a/src/components/InfiniteScrollContainer.tsx
+++ b/src/components/InfiniteScrollContainer.tsx
@@ -1,0 +1,28 @@
+import { useInView } from "react-intersection-observer";
+
+interface InfiniteScrollContainerProps extends React.PropsWithChildren {
+  onBottomReached: () => void;
+  className?: string;
+}
+
+export default function InfiniteScrollContainer({
+  onBottomReached,
+  className,
+  children,
+}: InfiniteScrollContainerProps) {
+  const { ref } = useInView({
+    rootMargin: "200px",
+    onChange(inView) {
+      if (inView) {
+        onBottomReached();
+      }
+    },
+  });
+
+  return (
+    <div className={className}>
+      {children}
+      <div ref={ref} />
+    </div>
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -8,3 +8,8 @@ export type PostData = Post & {
     avatarUrl: string | null;
   };
 };
+
+export interface PostsPage {
+  posts: PostData[];
+  nextCursor: string | null;
+}


### PR DESCRIPTION
This commit introduces infinite scrolling functionality to the "For You" post feed, enabling efficient loading of posts as the user scrolls.

- **API ():** Updated to support cursor-based pagination, accepting  and 16384 parameters, and returning a paginated data structure.
- **Frontend ():** Refactored to utilize  for fetching and managing paginated post data.
- **New Component ():** Added a dedicated component to handle scroll detection and trigger loading of subsequent pages.
- **Types ():** Introduced a new  interface to define the structure for paginated post responses.
- **Dependencies:** Added  to facilitate scroll detection.