### PR TITLE
fix: Remove unused import

### DIFF
--- a/src/app/(main)/profile/[username]/page.tsx
+++ b/src/app/(main)/profile/[username]/page.tsx
@@ -9,7 +9,6 @@ import UserAvatar from "@/components/UserAvatar";
 import { formatDate } from "date-fns";
 import { formatCount } from "@/lib/utils";
 import FollowersCount from "@/components/FollowersCount";
-import { Button } from "@/components/ui/button";
 import FollowButton from "@/components/FollowButton";
 import UsersPostFeed from "@/components/UsersPostFeed";
 import Linkify from "@/components/Linkify";


### PR DESCRIPTION
Removed an unused import of the `Button` component from the user profile page to resolve a linting issue.