### PR TITLE
feat: Implement media attachments for posts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -47,13 +47,31 @@ model Follow {
 }
 
 model Post {
-  id      String @id @default(cuid())
-  content String
-  userId  String
-  user    User   @relation(fields: [userId], references: [clerkId], onDelete: Cascade)
+  id          String  @id @default(cuid())
+  content     String
+  userId      String
+  user        User    @relation(fields: [userId], references: [clerkId], onDelete: Cascade)
+  attachments Media[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
   @@map("posts")
+}
+
+model Media {
+  id        String    @id @default(cuid())
+  postId    String?
+  post      Post?     @relation(fields: [postId], references: [id], onDelete: SetNull)
+  type      MediaType
+  url       String
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+
+  @@map("post_media")
+}
+
+enum MediaType {
+  IMAGE
+  VIDEO
 }

--- a/src/app/api/posts/following/route.ts
+++ b/src/app/api/posts/following/route.ts
@@ -52,6 +52,7 @@ export async function GET(request: NextRequest) {
         },
       },
       include: {
+        attachments: true,
         user: {
           select: {
             username: true,

--- a/src/app/api/posts/for-you/route.ts
+++ b/src/app/api/posts/for-you/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: NextRequest) {
     //
     const posts = await prisma.post.findMany({
       include: {
+        attachments: true,
         user: {
           select: {
             username: true,

--- a/src/app/api/user/[userId]/posts/route.ts
+++ b/src/app/api/user/[userId]/posts/route.ts
@@ -47,6 +47,7 @@ export async function GET(
         userId,
       },
       include: {
+        attachments: true,
         user: {
           select: {
             username: true,

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -3,11 +3,13 @@
 import type { PostData } from "@/lib/types";
 import Link from "next/link";
 import UserAvatar from "../UserAvatar";
-import { formatRelativeCreatedAt } from "@/lib/utils";
+import { cn, formatRelativeCreatedAt } from "@/lib/utils";
 import { useAuth } from "@/hooks/useAuth";
 import PostMenuButton from "./PostMenuButton";
 import Linkify from "../Linkify";
 import UserTooltip from "../UserTooltip";
+import { Media } from "@/generated/prisma";
+import Image from "next/image";
 
 interface PostProps {
   post: PostData;
@@ -55,6 +57,58 @@ export default function Post({ post }: PostProps) {
       <Linkify>
         <div className="whitespace-pre-line break-words">{post.content}</div>
       </Linkify>
+      {!!post.attachments.length && (
+        <MediaPreviews attachments={post.attachments} />
+      )}
     </article>
   );
+}
+
+interface MediaPreviewsProps {
+  attachments: Media[];
+}
+
+function MediaPreviews({ attachments }: MediaPreviewsProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3",
+        attachments.length > 1 && "sm:grid sm:grid-cols-2"
+      )}
+    >
+      {attachments.map((attachment) => (
+        <MediaPreview key={attachment.id} attachment={attachment} />
+      ))}
+    </div>
+  );
+}
+
+interface MediaPreviewProps {
+  attachment: Media;
+}
+
+function MediaPreview({ attachment }: MediaPreviewProps) {
+  if (attachment.type === "IMAGE") {
+    return (
+      <Image
+        src={attachment.url}
+        alt="Attachment"
+        width={500}
+        height={500}
+        className="mx-auto size-fit max-h-[30rem] rounded-2xl"
+      />
+    );
+  }
+
+  if (attachment.type === "VIDEO") {
+    return (
+      <video
+        src={attachment.url}
+        controls
+        className="mx-auto size-fit max-h-[30rem] rounded-2xl"
+      />
+    );
+  }
+
+  return <p className="text-destructive">Unsupported media type</p>;
 }

--- a/src/components/posts/editor/PostEditor.tsx
+++ b/src/components/posts/editor/PostEditor.tsx
@@ -6,13 +6,26 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { useAuth } from "@/hooks/useAuth";
 import UserAvatar from "@/components/UserAvatar";
 import "./styles.css";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useSubmitPostMutation } from "./mutations";
 import LoadingButton from "@/components/LoadingButton";
+import useMediaUpload, { type Attachment } from "@/hooks/useMediaUpload";
+import { Button } from "@/components/ui/button";
+import { ImageIcon, Loader2Icon, XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import Image from "next/image";
 
 export default function PostEditor() {
   const { userDetails } = useAuth();
   const [content, setContent] = useState("");
+  const {
+    attachments,
+    uploadProgress,
+    isUploading,
+    startUpload,
+    removeAttachment,
+    reset: resetMediaUpload,
+  } = useMediaUpload();
 
   const mutation = useSubmitPostMutation();
 
@@ -34,12 +47,21 @@ export default function PostEditor() {
   });
 
   async function onSubmit() {
-    mutation.mutate(content, {
-      onSuccess() {
-        editor?.commands.clearContent();
-        setContent("");
+    mutation.mutate(
+      {
+        content,
+        mediaIds: attachments
+          .map((attachment) => attachment.mediaId)
+          .filter(Boolean) as string[],
       },
-    });
+      {
+        onSuccess() {
+          editor?.commands.clearContent();
+          setContent("");
+          resetMediaUpload();
+        },
+      }
+    );
   }
 
   return (
@@ -54,16 +76,142 @@ export default function PostEditor() {
           className="w-full max-h-[20rem] overflow-y-auto bg-background rounded-2xl px-5 py-3"
         />
       </div>
-      <div className="flex justify-end">
+      {!!attachments.length && (
+        <AttachmentPreviews
+          attachments={attachments}
+          removeAttachment={removeAttachment}
+        />
+      )}
+      <div className="flex justify-end gap-3 items-center">
+        {isUploading && (
+          <>
+            <span>
+              {uploadProgress ?? 0}%
+              <Loader2Icon className="size-5 animate-spin text-primary" />
+            </span>
+          </>
+        )}
+        <AddAttachmentsButton
+          onFilesSelected={startUpload}
+          disabled={isUploading || attachments.length >= 5}
+        />
         <LoadingButton
           onClick={onSubmit}
           loading={mutation.isPending}
-          disabled={!content.trim()}
+          disabled={!content.trim() || isUploading}
           className="min-w-20"
         >
           Post
         </LoadingButton>
       </div>
+    </div>
+  );
+}
+
+interface AddAttachmentsButtonProps {
+  onFilesSelected: (files: File[]) => void;
+  disabled: boolean;
+}
+
+function AddAttachmentsButton({
+  onFilesSelected,
+  disabled,
+}: AddAttachmentsButtonProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <>
+      <Button
+        variant={"ghost"}
+        size="icon"
+        disabled={disabled}
+        className="text-primary hover:text-primary"
+        onClick={() => fileInputRef.current?.click()}
+      >
+        <ImageIcon size={20} />
+      </Button>
+      <input
+        type="file"
+        accept="image/*, video/*"
+        multiple
+        ref={fileInputRef}
+        className="hidden sr-only"
+        onChange={(e) => {
+          const files = Array.from(e.target.files || []);
+          if (files.length) {
+            onFilesSelected(files);
+            e.target.value = ""; // Reset input value
+          }
+        }}
+      ></input>
+    </>
+  );
+}
+
+interface AttachmentPreviewsProps {
+  attachments: Attachment[];
+  removeAttachment: (fileName: string) => void;
+}
+
+function AttachmentPreviews({
+  attachments,
+  removeAttachment,
+}: AttachmentPreviewsProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3",
+        attachments.length > 1 && "sm:grid sm:grid-cols-2"
+      )}
+    >
+      {attachments.map((attachment) => (
+        <AttachmentPreview
+          key={attachment.file.name}
+          attachment={attachment}
+          onRemoveClick={() => removeAttachment(attachment.file.name)}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface AttachmentPreviewProps {
+  attachment: Attachment;
+  onRemoveClick: () => void;
+}
+
+function AttachmentPreview({
+  attachment: { file, isUploading },
+  onRemoveClick,
+}: AttachmentPreviewProps) {
+  const src = URL.createObjectURL(file);
+
+  return (
+    <div
+      className={cn("relative mx-auto size-fit", isUploading && "opacity-50")}
+    >
+      {file.type.startsWith("image/") ? (
+        <Image
+          src={src}
+          alt="Attachment preview"
+          width={500}
+          height={500}
+          className="size-fit max-h-[30rem] rounded-2xl"
+        />
+      ) : (
+        <video controls className="size-fit max-h-[30rem] rounded-2xl">
+          <source src={src} type={file.type} />
+        </video>
+      )}
+
+      {!isUploading && (
+        <button
+          onClick={onRemoveClick}
+          className="absolute right-3 top-3 rounded-full bg-foreground p-1.5 text-background transition-colors hover:bg-foreground/60"
+        >
+          <XIcon size={20} />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/posts/editor/actions.ts
+++ b/src/components/posts/editor/actions.ts
@@ -4,19 +4,26 @@ import { prisma } from "@/lib/prisma";
 import { createPostSchema } from "@/lib/validation";
 import { auth } from "@clerk/nextjs/server";
 
-export async function submitPost(input: string) {
+export async function submitPost(input: {
+  content: string;
+  mediaIds?: string[];
+}) {
   const { userId } = await auth();
 
   if (!userId) throw new Error("Unauthorized: No valid session");
 
-  const { content } = createPostSchema.parse({ content: input });
+  const { content, mediaIds } = createPostSchema.parse(input);
 
   const newPost = await prisma.post.create({
     data: {
       content,
       userId,
+      attachments: {
+        connect: mediaIds.map((id) => ({ id })),
+      },
     },
     include: {
+      attachments: true,
       user: {
         select: {
           username: true,

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -1,0 +1,96 @@
+import { useUploadThing } from "@/lib/uploadthing";
+import { useState } from "react";
+import { toast } from "sonner";
+
+export interface Attachment {
+  file: File;
+  mediaId?: string;
+  isUploading: boolean;
+}
+
+export default function useMediaUpload() {
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
+
+  const [uploadProgress, setUploadProgress] = useState<number>();
+
+  const { startUpload, isUploading } = useUploadThing("attachment", {
+    onBeforeUploadBegin(files) {
+      const renamedFiles = files.map((file) => {
+        const extension = file.name.split(".").pop();
+
+        return new File(
+          [file],
+          `attachment_${crypto.randomUUID()}.${extension}`,
+          { type: file.type }
+        );
+      });
+      setAttachments((prev) => [
+        ...prev,
+        ...renamedFiles.map((file) => ({
+          file,
+          isUploading: true,
+        })),
+      ]);
+
+      return renamedFiles;
+    },
+    onUploadProgress: setUploadProgress,
+    onClientUploadComplete(res) {
+      setAttachments((prev) =>
+        prev.map((attachment) => {
+          const uploadResult = res.find(
+            (result) => result.name === attachment.file.name
+          );
+          if (!uploadResult) return attachment;
+
+          return {
+            ...attachment,
+            mediaId: uploadResult.serverData.mediaId,
+            isUploading: false,
+          };
+        })
+      );
+    },
+    onUploadError(error) {
+      setAttachments((prev) =>
+        prev.filter((attachment) => !attachment.isUploading)
+      );
+
+      toast.error(error.message || "Failed to upload media");
+    },
+  });
+
+  function handleStartUpload(files: File[]) {
+    if (isUploading) {
+      toast.error("Please wait for the current upload to finish.");
+      return;
+    }
+
+    if (attachments.length + files.length > 5) {
+      toast.error("You can only upload 5 attachments per post.");
+      return;
+    }
+
+    startUpload(files);
+  }
+
+  function removeAttachment(fileName: string) {
+    setAttachments((prev) =>
+      prev.filter((attachment) => attachment.file.name !== fileName)
+    );
+  }
+
+  function reset() {
+    setAttachments([]);
+    setUploadProgress(undefined);
+  }
+
+  return {
+    attachments,
+    uploadProgress,
+    isUploading,
+    startUpload: handleStartUpload,
+    removeAttachment,
+    reset,
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
-import type { Post } from "@/generated/prisma";
+import type { Media, Post } from "@/generated/prisma";
 
 export type PostData = Post & {
+  attachments: Media[];
   user: {
     username: string;
     firstName: string | null;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -7,6 +7,7 @@ const requiredString = z
 
 export const createPostSchema = z.object({
   content: requiredString,
+  mediaIds: z.array(z.string()).max(5, "Can not have more than 5 attachments."),
 });
 
 export const updateUserProfileSchema = z.object({


### PR DESCRIPTION
This feature allows users to attach images and videos to their posts. It includes:
- Database schema changes to support media attachments.
- API endpoint updates to handle media uploads and associations.
- Frontend components for creating and displaying posts with media previews.