### PR TITLE
feat(posts): Add drag-and-drop and paste-to-upload for images

### DIFF
--- a/src/components/posts/editor/PostEditor.tsx
+++ b/src/components/posts/editor/PostEditor.tsx
@@ -32,6 +32,7 @@ export default function PostEditor() {
     onDrop: startUpload,
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { onClick, ...rootProps } = getRootProps();
 
   const mutation = useSubmitPostMutation();

--- a/src/components/posts/editor/PostEditor.tsx
+++ b/src/components/posts/editor/PostEditor.tsx
@@ -6,7 +6,7 @@ import Placeholder from "@tiptap/extension-placeholder";
 import { useAuth } from "@/hooks/useAuth";
 import UserAvatar from "@/components/UserAvatar";
 import "./styles.css";
-import { useRef, useState } from "react";
+import { type ClipboardEvent, useRef, useState } from "react";
 import { useSubmitPostMutation } from "./mutations";
 import LoadingButton from "@/components/LoadingButton";
 import useMediaUpload, { type Attachment } from "@/hooks/useMediaUpload";
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { ImageIcon, Loader2Icon, XIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
+import { useDropzone } from "@uploadthing/react";
 
 export default function PostEditor() {
   const { userDetails } = useAuth();
@@ -26,6 +27,12 @@ export default function PostEditor() {
     removeAttachment,
     reset: resetMediaUpload,
   } = useMediaUpload();
+
+  const { getRootProps, getInputProps, isDragAccept } = useDropzone({
+    onDrop: startUpload,
+  });
+
+  const { onClick, ...rootProps } = getRootProps();
 
   const mutation = useSubmitPostMutation();
 
@@ -64,6 +71,14 @@ export default function PostEditor() {
     );
   }
 
+  function onPaste(e: ClipboardEvent<HTMLInputElement>) {
+    const files = Array.from(e.clipboardData.items)
+      .filter((item) => item.kind === "file")
+      .map((item) => item.getAsFile()) as File[];
+
+    if (files.length) startUpload(files);
+  }
+
   return (
     <div className="flex flex-col gap-5 rounded-2xl bg-card p-5 shadow-sm">
       <div className="flex gap-5">
@@ -71,10 +86,17 @@ export default function PostEditor() {
           avatarUrl={userDetails?.avatarUrl}
           className="hidden sm:inline"
         />
-        <EditorContent
-          editor={editor}
-          className="w-full max-h-[20rem] overflow-y-auto bg-background rounded-2xl px-5 py-3"
-        />
+        <div {...rootProps} className="w-full">
+          <EditorContent
+            editor={editor}
+            className={cn(
+              "w-full max-h-[20rem] overflow-y-auto bg-background rounded-2xl px-5 py-3",
+              isDragAccept && "outline-dashed"
+            )}
+            onPaste={onPaste}
+          />
+          <input {...getInputProps()} />
+        </div>
       </div>
       {!!attachments.length && (
         <AttachmentPreviews


### PR DESCRIPTION
This enhances the user experience by allowing images to be added to posts more intuitively. It implements drag-and-drop and paste-to-upload functionality in the post editor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for drag-and-drop and clipboard paste uploads of media attachments in the post editor.
  * Visual feedback is now shown when dragging files over the editor area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->