### PR TITLE
feat: Implement post liking functionality

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model User {
   posts      Post[]
   followers  Follow[] @relation("Followers")
   followings Follow[] @relation("Followings")
+  likes      Like[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -52,6 +53,7 @@ model Post {
   userId      String
   user        User    @relation(fields: [userId], references: [clerkId], onDelete: Cascade)
   attachments Media[]
+  likes       Like[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -74,4 +76,14 @@ model Media {
 enum MediaType {
   IMAGE
   VIDEO
+}
+
+model Like {
+  userId String
+  user   User   @relation(fields: [userId], references: [clerkId], onDelete: Cascade)
+  postId String
+  post   Post   @relation(fields: [postId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, postId])
+  @@map("likes")
 }

--- a/src/app/(main)/post/[postId]/page.tsx
+++ b/src/app/(main)/post/[postId]/page.tsx
@@ -46,6 +46,19 @@ const getPost = cache(async (postId: string, loggedInUserId: string) => {
         },
       },
       attachments: true,
+      likes: {
+        where: {
+          userId: loggedInUserId,
+        },
+        select: {
+          userId: true,
+        },
+      },
+      _count: {
+        select: {
+          likes: true, // Count the total number of likes for the post
+        },
+      },
     },
   });
 

--- a/src/app/api/posts/[postId]/likes/route.ts
+++ b/src/app/api/posts/[postId]/likes/route.ts
@@ -1,0 +1,200 @@
+import { prisma } from "@/lib/prisma";
+import type { LikeInfo } from "@/lib/types";
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/posts/{postId}/likes
+ *
+ * This endpoint returns the number of likes for a specific post and whether the currently authenticated user has liked it.
+ * It relies on Clerk’s `auth()` function to verify the user’s session.
+ *
+ * Path Parameters:
+ *  postId: The ID of the post to retrieve like information for.
+ *
+ * Response codes:
+ *  200 – OK, returns an object containing the number of likes and a boolean indicating if the user has liked the post.
+ *  401 – Unauthorized (no valid Clerk session)
+ *  404 – Not Found (post not found)
+ *  500 – Internal Server Error (unexpected exception)
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const { postId } = await params;
+  // Retrieve Clerk-authenticated user ID from the session.
+  // If there’s no valid session, `userId` will be undefined.
+  const { userId: authenticatedUserId } = await auth();
+
+  // If not signed in via Clerk, block the request.
+  if (!authenticatedUserId) {
+    return NextResponse.json(
+      { error: "Unauthorized: no valid session" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    //
+    // Query Prisma to get the like information for the specified post.
+    // This includes the total number of likes and whether the authenticated user has liked the post.
+    //
+    const post = await prisma.post.findUnique({
+      where: {
+        id: postId,
+      },
+      select: {
+        likes: {
+          where: {
+            userId: authenticatedUserId,
+          },
+          select: {
+            userId: true,
+          },
+        },
+        _count: {
+          select: {
+            likes: true, // Count the total number of likes for the post
+          },
+        },
+      },
+    });
+
+    if (!post) {
+      return NextResponse.json({ error: "Post not found" }, { status: 404 });
+    }
+
+    const data: LikeInfo = {
+      likes: post._count.likes,
+      isLikedByUser: !!post.likes.length,
+    };
+
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    // If anything goes wrong (e.g., database connectivity), log and return 500.
+    console.log("Error fetching likes: ", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/posts/{postId}/likes
+ *
+ * This endpoint allows an authenticated user to like a post. It uses an upsert operation
+ * to ensure that a user can only like a post once.
+ *
+ * Path Parameters:
+ *  postId: The ID of the post to like.
+ *
+ * Response codes:
+ *  200 – OK, returns a success message.
+ *  401 – Unauthorized (no valid Clerk session)
+ *  500 – Internal Server Error (unexpected exception)
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const { postId } = await params;
+  // Retrieve Clerk-authenticated user ID from the session.
+  // If there’s no valid session, `userId` will be undefined.
+  const { userId: authenticatedUserId } = await auth();
+
+  // If not signed in via Clerk, block the request.
+  if (!authenticatedUserId) {
+    return NextResponse.json(
+      { error: "Unauthorized: no valid session" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    //
+    // Upsert the like entry for the authenticated user and the specified post.
+    // If the like already exists, it will not create a duplicate.
+    // If it doesn't exist, it will create a new like entry.
+    //
+    await prisma.like.upsert({
+      where: {
+        userId_postId: {
+          userId: authenticatedUserId,
+          postId,
+        },
+      },
+      create: {
+        userId: authenticatedUserId,
+        postId,
+      },
+      update: {},
+    });
+
+    return NextResponse.json(
+      { message: "Post liked successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.log("Error liking post: ", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/posts/{postId}/likes
+ *
+ * This endpoint allows an authenticated user to remove their like from a post.
+ *
+ * Path Parameters:
+ *  postId: The ID of the post to unlike.
+ *
+ * Response codes:
+ *  200 – OK, returns a success message.
+ *  401 – Unauthorized (no valid Clerk session)
+ *  500 – Internal Server Error (unexpected exception)
+ */
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ postId: string }> }
+) {
+  const { postId } = await params;
+  // Retrieve Clerk-authenticated user ID from the session.
+  // If there’s no valid session, `userId` will be undefined.
+  const { userId: authenticatedUserId } = await auth();
+
+  // If not signed in via Clerk, block the request.
+  if (!authenticatedUserId) {
+    return NextResponse.json(
+      { error: "Unauthorized: no valid session" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    //
+    // Delete the like entry for the authenticated user and the specified post.
+    //
+    await prisma.like.deleteMany({
+      where: {
+        userId: authenticatedUserId,
+        postId,
+      },
+    });
+
+    return NextResponse.json(
+      { message: "Like removed successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.log("Error unliking post: ", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/posts/following/route.ts
+++ b/src/app/api/posts/following/route.ts
@@ -53,6 +53,19 @@ export async function GET(request: NextRequest) {
       },
       include: {
         attachments: true,
+        likes: {
+          where: {
+            userId: authenticatedUserId,
+          },
+          select: {
+            userId: true,
+          },
+        },
+        _count: {
+          select: {
+            likes: true, // Count the total number of likes for the post
+          },
+        },
         user: {
           select: {
             username: true,

--- a/src/app/api/posts/for-you/route.ts
+++ b/src/app/api/posts/for-you/route.ts
@@ -43,6 +43,19 @@ export async function GET(request: NextRequest) {
     const posts = await prisma.post.findMany({
       include: {
         attachments: true,
+        likes: {
+          where: {
+            userId: authenticatedUserId,
+          },
+          select: {
+            userId: true,
+          },
+        },
+        _count: {
+          select: {
+            likes: true, // Count the total number of likes for the post
+          },
+        },
         user: {
           select: {
             username: true,

--- a/src/app/api/user/[userId]/posts/route.ts
+++ b/src/app/api/user/[userId]/posts/route.ts
@@ -48,6 +48,19 @@ export async function GET(
       },
       include: {
         attachments: true,
+        likes: {
+          where: {
+            userId: authenticatedUserId,
+          },
+          select: {
+            userId: true,
+          },
+        },
+        _count: {
+          select: {
+            likes: true, // Count the total number of likes for the post
+          },
+        },
         user: {
           select: {
             username: true,

--- a/src/components/posts/LikeButton.tsx
+++ b/src/components/posts/LikeButton.tsx
@@ -1,0 +1,79 @@
+import kyInstance from "@/lib/ky";
+import type { LikeInfo } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { HeartIcon } from "lucide-react";
+import { toast } from "sonner";
+
+interface LikeButtonProps {
+  postId: string;
+  initialState: LikeInfo;
+}
+
+export default function LikeButton({ postId, initialState }: LikeButtonProps) {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery({
+    queryKey: ["like-info", postId],
+    queryFn: async () =>
+      kyInstance.get(`api/posts/${postId}/likes`).json<LikeInfo>(),
+
+    initialData: initialState,
+    staleTime: Infinity,
+  });
+
+  const { mutate } = useMutation({
+    mutationFn: () =>
+      data.isLikedByUser
+        ? kyInstance.delete(`api/posts/${postId}/likes`)
+        : kyInstance.post(`api/posts/${postId}/likes`),
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ["like-info", postId],
+      });
+
+      const previousState = queryClient.getQueryData<LikeInfo>([
+        "like-info",
+        postId,
+      ]);
+
+      queryClient.setQueryData<LikeInfo>(["like-info", postId], () => ({
+        likes:
+          (previousState?.likes || 0) + (previousState?.isLikedByUser ? -1 : 1),
+        isLikedByUser: !previousState?.isLikedByUser,
+      }));
+
+      return { previousState };
+    },
+
+    onError: (error, variables, context) => {
+      queryClient.setQueryData(["like-info", postId], context?.previousState);
+      console.error("Error updating like state:", error);
+
+      toast.error(
+        `Failed to ${data.isLikedByUser ? "unlike" : "like"} the post.`
+      );
+    },
+  });
+
+  return (
+    <button
+      onClick={() => mutate()}
+      className="flex items-center gap-2 cursor-pointer"
+    >
+      <HeartIcon
+        className={cn(
+          "size-5",
+          data.isLikedByUser && "fill-red-500 text-red-500"
+        )}
+      />
+
+      <span className="text-sm font-medium tabular-nums">
+        {data.likes}{" "}
+        <span className="hidden sm:inline">{` like${
+          data.likes === 1 ? "" : "s"
+        }`}</span>
+      </span>
+    </button>
+  );
+}

--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -10,6 +10,7 @@ import Linkify from "../Linkify";
 import UserTooltip from "../UserTooltip";
 import { Media } from "@/generated/prisma";
 import Image from "next/image";
+import LikeButton from "./LikeButton";
 
 interface PostProps {
   post: PostData;
@@ -61,6 +62,16 @@ export default function Post({ post }: PostProps) {
       {!!post.attachments.length && (
         <MediaPreviews attachments={post.attachments} />
       )}
+      <hr className="text-muted-foreground" />
+      <LikeButton
+        postId={post.id}
+        initialState={{
+          likes: post._count.likes,
+          isLikedByUser: post.likes.some(
+            (like) => like.userId === userDetails?.clerkId
+          ),
+        }}
+      />
     </article>
   );
 }

--- a/src/components/posts/editor/actions.ts
+++ b/src/components/posts/editor/actions.ts
@@ -24,6 +24,19 @@ export async function submitPost(input: {
     },
     include: {
       attachments: true,
+      likes: {
+        where: {
+          userId: userId,
+        },
+        select: {
+          userId: true,
+        },
+      },
+      _count: {
+        select: {
+          likes: true, // Count the total number of likes for the post
+        },
+      },
       user: {
         select: {
           username: true,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,12 @@ import type { Media, Post } from "@/generated/prisma";
 
 export type PostData = Post & {
   attachments: Media[];
+  likes: {
+    userId: string;
+  }[];
+  _count: {
+    likes: number; // Count the total number of likes for the post
+  };
   user: {
     username: string;
     firstName: string | null;
@@ -48,3 +54,8 @@ export type UserData = {
     posts: number;
   };
 };
+
+export interface LikeInfo {
+  likes: number;
+  isLikedByUser: boolean;
+}


### PR DESCRIPTION
This commit introduces the ability for users to like and unlike posts.

Key changes include:
- Added a `Like` model to the Prisma schema to store post likes.
- Updated the relevant API routes to include like data in post responses.
- Created a `LikeButton` component with optimistic updates for a seamless user experience.
- Integrated the `LikeButton` into the `Post` component.