### PR TITLE
fix(posts): Resolve like button hydration issue

### DIFF
--- a/src/components/posts/Post.tsx
+++ b/src/components/posts/Post.tsx
@@ -67,9 +67,7 @@ export default function Post({ post }: PostProps) {
         postId={post.id}
         initialState={{
           likes: post._count.likes,
-          isLikedByUser: post.likes.some(
-            (like) => like.userId === userDetails?.clerkId
-          ),
+          isLikedByUser: !!post.likes.length,
         }}
       />
     </article>


### PR DESCRIPTION
This commit addresses a hydration mismatch that caused the like button's state (the filled heart icon) to be incorrect on initial page load in the production environment.

The root cause was that the `isLikedByUser` prop was being determined using the client-side `useAuth()` hook, which is not available during server-side rendering. This led to a discrepancy between the server-rendered HTML and the client-rendered component, causing React to default to the server's incorrect state.

The fix is to derive the `isLikedByUser` state directly from the `post.likes` array, which is included in the initial server-side data fetch. By checking `post.likes.length > 0`, we ensure the initial state is consistent between the server and the client,
eliminating the hydration error.

Fixes #37